### PR TITLE
Added scoreboard overlays

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,14 +5,14 @@ set(PKG_VERSION "v1.2.0")
 project(hypseus)
 
 option(BENCHMARK    "Benchmark"  OFF)
-option(DEBUG        "Debug"      OFF)
+option(DEBUG        "Debug"      ON)
 option(VLDP_DEBUG   "VLDP Debug" OFF)
 option(CPU_DEBUG    "CPU Debug"  OFF)
 option(BUILD_SINGE  "Singe"      OFF)
 option(BUILDBOT     "Buildbot"   OFF)
 
 if( NOT CMAKE_BUILD_TYPE )
-    set(CMAKE_BUILD_TYPE "Release")
+    set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,14 +5,14 @@ set(PKG_VERSION "v1.2.0")
 project(hypseus)
 
 option(BENCHMARK    "Benchmark"  OFF)
-option(DEBUG        "Debug"      ON)
+option(DEBUG        "Debug"      OFF)
 option(VLDP_DEBUG   "VLDP Debug" OFF)
 option(CPU_DEBUG    "CPU Debug"  OFF)
 option(BUILD_SINGE  "Singe"      OFF)
 option(BUILDBOT     "Buildbot"   OFF)
 
 if( NOT CMAKE_BUILD_TYPE )
-    set(CMAKE_BUILD_TYPE "Debug")
+    set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall")

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -486,11 +486,10 @@ void game::blit()
 
         // MAC: No software scaling to be done on SDL2, so we just update the texture here,
         // and SDL_RenderCopy() will hw-scale for us.
-      
-        // video::vid_update_overlay_surface(m_video_overlay[m_active_video_overlay], 0, 0);
+        video::vid_update_overlay_surface(m_video_overlay[m_active_video_overlay], 0, 0);
         m_finished_video_overlay = m_active_video_overlay;
     }
-    //video::vid_blit();
+    video::vid_blit();
 }
 
 // forces the video overlay to be redrawn to the screen

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1024,8 +1024,6 @@ const char *game::get_address_name(unsigned int addr)
 
 bool game::getMouseEnabled() { return m_bMouseEnabled; }
 
-bool game::getGameUsesOverlay() { return m_game_uses_video_overlay; }
-
 bool game::getGameNeedsOverlayUpdate() { return m_video_overlay_needs_update; }
 
 void game::setGameNeedsOverlayUpdate(bool val) { m_video_overlay_needs_update = val; }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -466,10 +466,10 @@ void Scale(SDL_Surface *src, SDL_Surface *dst, long *matrix)
 // will call repaint()
 void game::blit()
 {
-    // if something has actually changed in the game's video (blit() will
+    // if something has actually changed in the game's video, blit() will
     // probably get called regularly on each screen refresh,
     // and we don't want to call the potentially expensive repaint()
-    // unless we have to)
+    // unless we have to.
     if (m_video_overlay_needs_update) {
         m_active_video_overlay++; // move to the next video buffer (in case we
                                   // are supporting more than one buffer)
@@ -484,25 +484,13 @@ void game::blit()
             false; // game will need to set this value to true next time it
                    // becomes needful for us to redraw the screen
 
-        // if we are in non-VLDP mode, then we can blit to the main surface
-        // right here,
-        // otherwise we do nothing because the yuv_callback in ldp-vldp.cpp will
-        // take care of it
-        //if (!g_ldp->is_vldp()) {
-        //        // If we're not scaling the video
-        //        if (!m_bFullScale) {
-        //            vid_blit(m_video_overlay[m_active_video_overlay], 0, 0);
-        //        } else {
-        //            // scale game graphics to the screen dimensions
-        //            Scale(m_video_overlay[m_active_video_overlay],
-        //                  m_video_overlay_scaled, m_video_overlay_matrix);
-        //            vid_blit(m_video_overlay_scaled, 0, 0);
-        //        } /*endelse*/
-        //        vid_flip();
-        //} // end if this isn't VLDP
-
+        // MAC: No software scaling to be done on SDL2, so we just update the texture here,
+        // and SDL_RenderCopy() will hw-scale for us.
+      
+        // video::vid_update_overlay_surface(m_video_overlay[m_active_video_overlay], 0, 0);
         m_finished_video_overlay = m_active_video_overlay;
     }
+    //video::vid_blit();
 }
 
 // forces the video overlay to be redrawn to the screen
@@ -1035,3 +1023,9 @@ const char *game::get_address_name(unsigned int addr)
 #endif //cpu::type::DEBUG
 
 bool game::getMouseEnabled() { return m_bMouseEnabled; }
+
+bool game::getGameUsesOverlay() { return m_game_uses_video_overlay; }
+
+bool game::getGameNeedsOverlayUpdate() { return m_video_overlay_needs_update; }
+
+void game::setGameNeedsOverlayUpdate(bool val) { m_video_overlay_needs_update = val; }

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -244,8 +244,6 @@ class game
     // returns m_bMouseEnabled
     bool getMouseEnabled();
     
-    bool getGameUsesOverlay();
-    
     bool getGameNeedsOverlayUpdate();
     
     void setGameNeedsOverlayUpdate(bool);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -243,6 +243,12 @@ class game
 
     // returns m_bMouseEnabled
     bool getMouseEnabled();
+    
+    bool getGameUsesOverlay();
+    
+    bool getGameNeedsOverlayUpdate();
+    
+    void setGameNeedsOverlayUpdate(bool);
 
     // some platforms have problems with SDL acceleration.
     bool m_sdl_software_rendering;

--- a/src/ldp-out/ldp-vldp.cpp
+++ b/src/ldp-out/ldp-vldp.cpp
@@ -1458,13 +1458,15 @@ int prepare_frame_callback(uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane,
 {
     int result = VLDP_FALSE;
 
-    // MAC: SDL call moved to the sdl_video_run thread.
+    // MAC: SDL call moved to the sdl_video_run thread. In fact, at this point we only update a yuv surface
+    // we have invented (because YUV surfaces don't exist in SDL2).
     /* result = (SDL_UpdateYUVTexture(g_yuv_texture, NULL, Yplane, Ypitch, Uplane,
                                    Upitch, Vplane, Vpitch) == 0)
                  ? VLDP_TRUE
                  : VLDP_FALSE;
     */
-    result = (video::vid_update_yuv_texture (Yplane, Uplane, Vplane, Ypitch, Upitch, Vpitch) == 0)
+    
+    result = (video::vid_update_yuv_surface (Yplane, Uplane, Vplane, Ypitch, Upitch, Vpitch) == 0)
                  ? VLDP_TRUE
                  : VLDP_FALSE;
 
@@ -1479,7 +1481,7 @@ void display_frame_callback()
     // MAC: It's VERY important that SDL_RenderCopy(), SDL_RenderPresent(), etc... are all on the same thread,
     // or we could be ending up trying to flip on a thread while updating the renderer on anorther thread!!
     // The same for SDL_UpdateTexture().
-    video::vid_blit();
+    //video::vid_blit();
 }
 
 ///////////////////
@@ -1643,10 +1645,7 @@ void report_mpeg_dimensions_callback(int width, int height)
         // MAC: SDL_CreateTexture() call moved to sdl_video_run thread. 
 	/* g_yuv_texture = SDL_CreateTexture(video::get_renderer(), SDL_PIXELFORMAT_YV12,
                                           SDL_TEXTUREACCESS_STATIC, width, height);*/
-        g_yuv_texture = video::sdl_video_run_create_yuv_texture(width, height);
-
-        // MAC: Register the vldp YUV texture on video class
-        // video::vid_register_yuv_texture(g_yuv_texture);
+        g_yuv_texture = video::vid_create_yuv_texture(width, height);
 
         // safety check
         if (!g_yuv_texture) {

--- a/src/ldp-out/ldp-vldp.cpp
+++ b/src/ldp-out/ldp-vldp.cpp
@@ -1476,21 +1476,10 @@ void display_frame_callback()
 {
     // SDL_Surface *gamevid = g_game->get_finished_video_overlay();
  
-    //if (!g_game->getGameUsesOverlay()) {
-        /*if (g_game->getGameNeedsOverlayUpdate()) {
-            // If the game needs to update the overlay again, he has to tell us.
-            g_game->setGameNeedsOverlayUpdate(false);
-            // Update normal overlay texture. The scoreboard LEDs texture is updated whenever scoreboard.cpp wants.
-            //video::vid_update_overlay_texture(gamevid, 0, 0);
-        }*/
-    //}
-
     // MAC: It's VERY important that SDL_RenderCopy(), SDL_RenderPresent(), etc... are all on the same thread,
     // or we could be ending up trying to flip on a thread while updating the renderer on anorther thread!!
     // The same for SDL_UpdateTexture().
-    //video::vid_set_yuv_video_needs_update(true);    
     video::vid_blit();
-    //video::vid_flip();
 }
 
 ///////////////////

--- a/src/sound/pc_beeper.cpp
+++ b/src/sound/pc_beeper.cpp
@@ -70,7 +70,7 @@ int init(Uint32 unused)
 
 #ifdef DEBUG
     // a couple of assumptions...
-    assert(sound::HANNELS == 2);
+    assert(sound::CHANNELS == 2);
     assert(sound::BYTES_PER_SAMPLE == 4);
 #endif
 

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -793,10 +793,12 @@ void vid_destroy_texture (SDL_Texture *texture) {
     SDL_UnlockMutex(sdl_video_run_mutex);
 }
 
+// Does the overlay texture need to be updated on VIDEO_RUN_BLIT?
 void vid_set_overlay_needs_update(bool needs) {
     g_overlay_needs_update = needs;
 }
 
+// Does the yuv texture need to be updated on VIDEO_RUN_BLIT?
 void vid_set_yuv_video_needs_update(bool needs) {
     g_yuv_video_needs_update = needs;
 }

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -42,19 +42,19 @@
 #include <string> // for some error messages
 
 // MAC: sdl_video_run thread defines block
-#define SDL_VIDEO_RUN_INIT			1
-#define SDL_VIDEO_RUN_UPDATE_RENDERER		2
-#define SDL_VIDEO_RUN_UPDATE_YUV_TEXTURE	3
-#define SDL_VIDEO_RUN_CREATE_YUV_TEXTURE	4
-#define SDL_VIDEO_RUN_DESTROY_TEXTURE		5
-#define SDL_VIDEO_RUN_END_THREAD		6
+#define SDL_VIDEO_RUN_BLIT                      0
+#define SDL_VIDEO_RUN_UPDATE_YUV_TEXTURE	4
+#define SDL_VIDEO_RUN_CREATE_YUV_TEXTURE	5
+#define SDL_VIDEO_RUN_DESTROY_TEXTURE		7
+//#define SDL_VIDEO_RUN_FLIP			8
+#define SDL_VIDEO_RUN_END_THREAD		9
 
 using namespace std;
 
 namespace video
 {
-unsigned int g_vid_width = 640, g_vid_height = 480; // default video width and
-                                                    // video height
+int g_vid_width = 640, g_vid_height = 480; // default video dimensions
+
 #ifdef DEBUG
 const Uint16 cg_normalwidths[]  = {320, 640, 800, 1024, 1280, 1280, 1600};
 const Uint16 cg_normalheights[] = {240, 480, 600, 768, 960, 1024, 1200};
@@ -67,15 +67,23 @@ const Uint16 cg_normalheights[] = {480, 600, 768, 960, 1024, 1200};
 // ratio is enforced)
 unsigned int g_draw_width = 640, g_draw_height = 480;
 
+// the current game overlay dimensions
+unsigned int g_overlay_width = 0, g_overlay_height = 0;
+
 FC_Font *g_font                    = NULL;
-SDL_Texture *g_led_bmps[LED_RANGE] = {0};
-SDL_Texture *g_other_bmps[B_EMPTY] = {0};
+SDL_Surface *g_led_bmps[LED_RANGE] = {0};
+SDL_Surface *g_other_bmps[B_EMPTY] = {0};
 SDL_Window *g_window               = NULL;
 SDL_Renderer *g_renderer           = NULL;
-SDL_Texture *g_screen              = NULL; // our primary display
-SDL_Surface *g_screen_blitter = NULL; // the surface we blit to (we don't blit
-                                      // directly to g_screen because opengl
-                                      // doesn't like that)
+SDL_Texture *g_overlay_texture     = NULL; // The OVERLAY texture, excluding LEDs wich are a special case
+SDL_Texture *g_yuv_texture         = NULL; // The YUV video texture, registered from ldp-vldp.cpp
+SDL_Surface *g_screen_blitter      = NULL; // The main blitter surface
+SDL_Surface *g_leds_surface        = NULL;
+
+SDL_Rect g_overlay_size_rect; 
+SDL_Rect g_display_size_rect = {0, 0, g_vid_width, g_vid_height};
+SDL_Rect g_leds_size_rect = {0, 0, 320, 240}; 
+
 bool g_fullscreen = false; // whether we should initialize video in fullscreen
                            // mode or not
 int g_scalefactor = 100;   // by RDG2010 -- scales the image to this percentage
@@ -93,14 +101,23 @@ float g_fRotateDegrees = 0.0;
 SDL_Thread *sdl_video_run_thread;
 SDL_cond *sdl_video_run_cond;
 SDL_mutex *sdl_video_run_mutex;
+SDL_mutex *leds_surface_mutex;
+SDL_mutex *overlay_surface_mutex;
 bool sdl_video_run_loop = true;
 int sdl_video_run_action = 0;
 int sdl_video_run_result = 0;
 
+// SDL sdl_video_run thread function prototypes
+void sdl_video_run_rendercopy (SDL_Renderer *renderer, SDL_Texture *texture, SDL_Rect *src, SDL_Rect* dst);
+
 // SDL Texture creation, update and destruction parameters
-SDL_Texture *sdl_yuv_texture;
 int yuv_texture_width;
 int yuv_texture_height;
+SDL_Renderer *sdl_renderer;
+SDL_Texture *yuv_texture;
+SDL_Texture *sdl_texture;
+SDL_Rect *sdl_rect_src;
+SDL_Rect *sdl_rect_dst;
 
 // SDL YUV texture update parameters
 uint8_t *yuv_texture_Yplane;
@@ -109,6 +126,11 @@ uint8_t *yuv_texture_Vplane;
 int yuv_texture_Ypitch;
 int yuv_texture_Upitch;
 int yuv_texture_Vpitch;
+
+// Scoreboard parameters
+bool g_scoreboard_needs_update = false;
+bool g_overlay_needs_update    = false;
+bool g_yuv_video_needs_update  = false;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -129,6 +151,9 @@ bool init_display()
 
         g_draw_width  = g_vid_width;
         g_draw_height = g_vid_height;
+
+        g_overlay_width = g_game->get_video_overlay_width();
+        g_overlay_height = g_game->get_video_overlay_height();
 
         // if we're supposed to enforce the aspect ratio ...
         if (g_bForceAspectRatio) {
@@ -167,10 +192,13 @@ bool init_display()
         } else {
             if (g_game->m_sdl_software_rendering) {
                 g_renderer = SDL_CreateRenderer(g_window, -1, SDL_RENDERER_SOFTWARE |
-                                                              SDL_RENDERER_TARGETTEXTURE);
+                                                              SDL_RENDERER_TARGETTEXTURE |
+                                                              SDL_RENDERER_PRESENTVSYNC
+                                                              );
             } else {
                 g_renderer = SDL_CreateRenderer(g_window, -1, SDL_RENDERER_ACCELERATED |
-                                                              SDL_RENDERER_TARGETTEXTURE);
+                                                              SDL_RENDERER_TARGETTEXTURE |
+                                                              SDL_RENDERER_PRESENTVSYNC);
             }
 
             if (!g_renderer) {
@@ -189,28 +217,35 @@ bool init_display()
                 FC_LoadFont(g_font, g_renderer, "fonts/default.ttf", 18,
                             FC_MakeColor(0, 0, 0, 255), TTF_STYLE_NORMAL);
 
-                g_screen = SDL_CreateTexture(g_renderer, SDL_PIXELFORMAT_RGBA8888,
-                                             SDL_TEXTUREACCESS_TARGET,
-                                             g_vid_width, g_vid_height);
+                // Create a 32-bit surface with alpha component. As big as an overlay can possibly be...
+		    int surfacebpp;
+		    Uint32 Rmask, Gmask, Bmask, Amask;              
+		    SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_RGBA8888, &surfacebpp, &Rmask, &Gmask, &Bmask, &Amask);
+		    g_screen_blitter =
+			SDL_CreateRGBSurface(SDL_SWSURFACE, g_overlay_width, g_overlay_height,
+					    surfacebpp, Rmask, Gmask, Bmask, Amask);
 
-                // create a 24-bit surface
-                g_screen_blitter =
-                    SDL_CreateRGBSurface(SDL_SWSURFACE, g_vid_width, g_vid_height,
-                                         24, 0xff, 0xFF00, 0xFF0000, 0xFF000000);
+		    g_leds_surface =
+			SDL_CreateRGBSurface(SDL_SWSURFACE, 320, 240,
+					    surfacebpp, Rmask, Gmask, Bmask, Amask);
 
-                if (g_screen && g_screen_blitter) {
-
-                    LOGI << fmt("Set %dx%d at %d bpp, flags: %x",
-                                g_screen_blitter->w, g_screen_blitter->h,
-                                g_screen_blitter->format->BitsPerPixel,
-                                g_screen_blitter->flags);
-
-                    SDL_SetRenderDrawColor(g_renderer, 0, 0, 0, 255);
-                    SDL_RenderClear(g_renderer);
-                    SDL_RenderPresent(g_renderer);
-                    // NOTE: SDL Console was initialized here.
-                    result = true;
+                // MAC: If the game uses an overlay, create a surface a texture for it.
+                // The g_screen_blitter surface is used from game.cpp anyway, so we always create it, used or not.
+		if (g_overlay_width && g_overlay_height) {
+		    g_overlay_texture = SDL_CreateTexture(g_renderer, SDL_PIXELFORMAT_RGBA8888,
+						 SDL_TEXTUREACCESS_TARGET,
+						 g_overlay_width, g_overlay_height);
+		   
+		    
+		    SDL_SetTextureBlendMode(g_overlay_texture, SDL_BLENDMODE_BLEND);
+		    SDL_SetTextureAlphaMod(g_overlay_texture, 255);
                 }
+
+                SDL_SetRenderDrawColor(g_renderer, 0, 0, 0, 255);
+                SDL_RenderClear(g_renderer);
+                SDL_RenderPresent(g_renderer);
+                // NOTE: SDL Console was initialized here.
+                result = true;
             }
         }
     } else {
@@ -227,7 +262,8 @@ bool init_display()
 bool deinit_display()
 {
 	SDL_FreeSurface(g_screen_blitter);
-	SDL_DestroyTexture(g_screen);
+	SDL_FreeSurface(g_leds_surface);
+	SDL_DestroyTexture(g_overlay_texture);
 	SDL_DestroyRenderer(g_renderer);
 	return (true);
 }
@@ -240,27 +276,11 @@ void shutdown_display()
     SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 
-void vid_flip()
-{
-    // SDL_RenderCopy(g_renderer, g_screen, NULL, NULL);
-    SDL_RenderPresent(g_renderer);
-}
-
+// Clear the renderer. Good for avoiding texture mess (YUV, LEDs, Overlay...)
 void vid_blank()
 {
     SDL_SetRenderDrawColor(g_renderer, 0, 0, 0, 255);
     SDL_RenderClear(g_renderer);
-}
-
-void vid_blit(SDL_Texture *tx, int x, int y)
-{
-    SDL_SetRenderTarget(g_renderer, g_screen);
-    SDL_Rect dest;
-    dest.x = (short)x;
-    dest.y = (short)y;
-    SDL_QueryTexture(tx, NULL, NULL, &dest.w, &dest.h);
-    SDL_RenderCopy(g_renderer, tx, NULL, &dest);
-    SDL_SetRenderTarget(g_renderer, NULL);
 }
 
 // redraws the proper display (Scoreboard, etc) on the screen, after first
@@ -269,7 +289,7 @@ void vid_blit(SDL_Texture *tx, int x, int y)
 void display_repaint()
 {
     vid_blank();
-    vid_flip();
+    //vid_flip();
     g_game->force_blit();
 }
 
@@ -301,9 +321,15 @@ bool load_bmps()
     g_other_bmps[B_GAMENOWOOK]     = load_one_bmp("pics/gamenowook.bmp");
 
     if (sboverlay_characterset != 2)
-        g_other_bmps[B_OVERLAY_LEDS] = load_one_bmp("pics/overlayleds1.bmp");
+	g_other_bmps[B_OVERLAY_LEDS] = load_one_bmp("pics/overlayleds1.bmp");
     else
-        g_other_bmps[B_OVERLAY_LEDS] = load_one_bmp("pics/overlayleds2.bmp");
+	g_other_bmps[B_OVERLAY_LEDS] = load_one_bmp("pics/overlayleds2.bmp");
+    
+    // MAC : Strange way to detect if we're using an overlay, but well, this is a mess anyway, so...
+    if (g_screen_blitter) { 
+	g_other_bmps[B_OVERLAY_LEDS] = SDL_ConvertSurface(g_other_bmps[B_OVERLAY_LEDS], g_screen_blitter->format, 0);
+        SDL_SetColorKey (g_other_bmps[B_OVERLAY_LEDS], 1, 0x000000ff);
+    }
 
     g_other_bmps[B_OVERLAY_LDP1450] = load_one_bmp("pics/ldp1450font.bmp");
 
@@ -317,21 +343,32 @@ bool load_bmps()
     return (result);
 }
 
-SDL_Texture *load_one_bmp(const char *filename)
+//SDL_Surface *load_one_bmp(const char *filename)
+SDL_Surface *load_one_bmp(const char *filename)
+{
+    SDL_Surface *result  = SDL_LoadBMP(filename);
+
+    if (!result)
+        LOGW << fmt("Could not load bitmap: %s", SDL_GetError());
+ 
+    return (result);
+}
+
+/*SDL_Texture *load_one_bmp(const char *filename)
 {
     SDL_Texture *texture = NULL;
     SDL_Surface *result  = SDL_LoadBMP(filename);
 
     if (result) texture = SDL_CreateTextureFromSurface(g_renderer, result);
-
+    
     if (!texture) {
         LOGW << fmt("Could not load bitmap: %s", SDL_GetError());
     } else {
         SDL_FreeSurface(result);
     }
-
+    
     return (texture);
-}
+}*/
 
 // Draw's one of our LED's to the screen
 // value contains the bitmap to draw (0-9 is valid)
@@ -340,11 +377,11 @@ SDL_Texture *load_one_bmp(const char *filename)
 // 1 is returned on success, 0 on failure
 bool draw_led(int value, int x, int y)
 {
-    vid_blit(g_led_bmps[value], x, y);
+    //vid_blit(g_led_bmps[value], x, y);
     return true;
 }
 
-// Draw overlay digits to the screen
+// Update scoreboard surface
 void draw_overlay_leds(unsigned int values[], int num_digits, int start_x,
                        int y, SDL_Surface *overlay)
 {
@@ -358,17 +395,29 @@ void draw_overlay_leds(unsigned int values[], int num_digits, int start_x,
     src.y = 0;
     src.w = OVERLAY_LED_WIDTH;
     src.h = OVERLAY_LED_HEIGHT;
-
-    /* Draw the digit(s) */
+    
+    // The leds surface is accessed from VIDEO_RUN_BLIT, which is called from the vldp thread, so it's access
+    // must be "protected". The same happens with g_scoreboard_needs_update.
+    SDL_LockMutex(leds_surface_mutex);
+    // Draw the digit(s) to the overlay surface
     for (int i = 0; i < num_digits; i++) {
         src.x = values[i] * OVERLAY_LED_WIDTH;
-        SDL_RenderCopy(g_renderer, g_other_bmps[B_OVERLAY_LEDS], &src, &dest);
+
+        // MAC : We need to call SDL_FillRect() here if we don't want our LED characters to "overlap", because
+        // we set the g_other_bmps[B_OVERLAY_LEDS] color key in such a way black is not being copied
+        // so segments are not clean when we go from 0 to 1, for example.
+        SDL_FillRect(g_leds_surface, &dest, 0x00000000); 
+        SDL_BlitSurface(g_other_bmps[B_OVERLAY_LEDS], &src, g_leds_surface, &dest);
+
         dest.x += OVERLAY_LED_WIDTH;
     }
 
-    dest.x = start_x;
-    dest.w = num_digits * OVERLAY_LED_WIDTH;
-    // SDL_UpdateRects(overlay, 1, &dest); FIXME
+    g_scoreboard_needs_update = true;
+
+    SDL_UnlockMutex(leds_surface_mutex);
+    // MAC: Even if we updated the overlay surface here, there's no need to do not-thread-safe stuff
+    // like SDL_UpdateTexture(), SDL_RenderCopy(), etc... until we are going to compose a final frame
+    // with the YUV texture and the overlay on top (which is issued from vldp for now) in VIDEO_RUN_BLIT.
 }
 
 // Draw LDP1450 overlay characters to the screen (added by Brad O.)
@@ -420,7 +469,7 @@ void draw_singleline_LDP1450(char *LDP1450_String, int start_x, int y, SDL_Surfa
                           // space
 
         src.x = value * OVERLAY_LDP1450_WIDTH;
-        SDL_RenderCopy(g_renderer, g_other_bmps[B_OVERLAY_LDP1450], &src, &dest);
+        //SDL_RenderCopy(g_renderer, g_other_bmps[B_OVERLAY_LDP1450], &src, &dest);
 
         dest.x += OVERLAY_LDP1450_CHARACTER_SPACING;
     }
@@ -437,7 +486,7 @@ bool draw_othergfx(int which, int x, int y, bool bSendToScreenBlitter)
 {
     // NOTE : this is drawn to g_screen_blitter, not to g_screen,
     //  to be more friendly to our opengl implementation!
-    SDL_Texture *tx = g_other_bmps[which];
+    /*SDL_Texture *tx = g_other_bmps[which];
     SDL_Rect dest;
     dest.x = (short)x;
     dest.y = (short)y;
@@ -449,8 +498,8 @@ bool draw_othergfx(int which, int x, int y, bool bSendToScreenBlitter)
     }
     // else blit it now
     else {
-        vid_blit(g_other_bmps[which], x, y);
-    }
+        //vid_blit(g_other_bmps[which], x, y);
+    }*/
     return true;
 }
 
@@ -472,17 +521,15 @@ void free_bmps()
     }
 }
 
-void free_one_bmp(SDL_Texture *candidate) { 
-	// MAC: Call moved to sdl_video_run thread
-	// SDL_DestroyTexture(candidate); 
-	sdl_video_run_destroy_texture(candidate);
+void free_one_bmp(SDL_Surface *candidate) { 
+	SDL_FreeSurface(candidate); 
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
 SDL_Renderer *get_renderer() { return g_renderer; }
 
-SDL_Texture *get_screen() { return g_screen; }
+SDL_Texture *get_screen() { return g_overlay_texture; }
 
 SDL_Surface *get_screen_blitter() { return g_screen_blitter; }
 
@@ -577,9 +624,7 @@ unsigned int get_draw_width() { return g_draw_width; }
 unsigned int get_draw_height() { return g_draw_height; }
 
 int sdl_video_run (void *data) {
-	
 	init_display();
-	
 	while (sdl_video_run_loop) {
 		// MAC: We signal upon entering the thread loop to notify
 		// the hypseus thread that init_display has returned.
@@ -590,21 +635,45 @@ int sdl_video_run (void *data) {
 		SDL_CondWait(sdl_video_run_cond, sdl_video_run_mutex);
 		SDL_UnlockMutex(sdl_video_run_mutex);
 		switch (sdl_video_run_action) {
-			case SDL_VIDEO_RUN_UPDATE_RENDERER:		
-				SDL_RenderCopy(get_renderer(), sdl_yuv_texture, NULL, NULL);
-				SDL_RenderPresent(get_renderer()); // display it!
-				break;
+			case SDL_VIDEO_RUN_BLIT:		
+                                // Always RenderCopy the YUV texture (if we're calling BLIT from vldp...)
+                                SDL_RenderCopy(g_renderer, g_yuv_texture, NULL, NULL);
+                                if(g_scoreboard_needs_update) {
+					// LEDs surface and update boolean both can be accessed randomly by 
+                                        // draw_overlay_leds(), and for now VIDEO_RUN_BLIT is called from the
+                                        // vldp thread, so it needs to be "protected".
+                                        SDL_LockMutex(leds_surface_mutex);
+					SDL_UpdateTexture(g_overlay_texture, &g_leds_size_rect,
+					    (void *)g_leds_surface->pixels, g_leds_surface->pitch);
+					g_scoreboard_needs_update = false;
+					SDL_UnlockMutex(leds_surface_mutex);
+                                }
+			        
+                                // If there's an overlay texture, it means we are using some kind of overlay,
+                                // be it LEDs or any other thing, so RenderCopy it to the renderer ON TOP of the YUV video.
+                                // ONLY a rect of the LEDs surface size is copied for now.
+                                if(g_overlay_texture) {
+                                    SDL_RenderCopy(g_renderer, g_overlay_texture, &g_leds_size_rect, NULL);
+                                }
+                                // Issue flip.
+                                SDL_RenderPresent(g_renderer);
+                                break;
+                        // MAC: There's no need for separated flip case because we always issue flip just after we update.
+                        /*case SDL_VIDEO_RUN_FLIP:
+				SDL_RenderPresent(g_renderer); // issue flip
+                                break;*/
 			case SDL_VIDEO_RUN_CREATE_YUV_TEXTURE:
-				sdl_yuv_texture = SDL_CreateTexture(get_renderer(), SDL_PIXELFORMAT_YV12,
-                                	SDL_TEXTUREACCESS_STATIC, yuv_texture_width, yuv_texture_height);
-				break;		
-			case SDL_VIDEO_RUN_UPDATE_YUV_TEXTURE:
-				sdl_video_run_result = SDL_UpdateYUVTexture(sdl_yuv_texture, NULL,
+				sdl_texture = SDL_CreateTexture(get_renderer(), SDL_PIXELFORMAT_YV12,
+                                	SDL_TEXTUREACCESS_STREAMING, yuv_texture_width, yuv_texture_height);
+                                g_yuv_texture = sdl_texture;
+                                break;		
+			case SDL_VIDEO_RUN_UPDATE_YUV_TEXTURE:		
+				sdl_video_run_result = SDL_UpdateYUVTexture(g_yuv_texture, NULL,
 					yuv_texture_Yplane, yuv_texture_Ypitch, yuv_texture_Uplane,
 					yuv_texture_Upitch, yuv_texture_Vplane, yuv_texture_Vpitch);
-				break;
-			case SDL_VIDEO_RUN_DESTROY_TEXTURE:
-        			SDL_DestroyTexture(sdl_yuv_texture);
+                                break;
+                        case SDL_VIDEO_RUN_DESTROY_TEXTURE:
+        			SDL_DestroyTexture(sdl_texture);
 				break;
 			case SDL_VIDEO_RUN_END_THREAD:
 				sdl_video_run_loop = false;
@@ -620,6 +689,8 @@ int sdl_video_run (void *data) {
 bool sdl_video_run_start () {
 	sdl_video_run_mutex = SDL_CreateMutex();
 	sdl_video_run_cond = SDL_CreateCond();
+        leds_surface_mutex = SDL_CreateMutex();
+        overlay_surface_mutex = SDL_CreateMutex();
 
 	// Create thread, then wait for it to signal. 
 	// When it signals, it means init_display() has returned and 
@@ -642,14 +713,13 @@ SDL_Texture *sdl_video_run_create_yuv_texture (int width, int height) {
 	SDL_CondSignal(sdl_video_run_cond);
 	SDL_CondWait(sdl_video_run_cond, sdl_video_run_mutex);
 	SDL_UnlockMutex(sdl_video_run_mutex);
-	return sdl_yuv_texture;
+	return sdl_texture;
 }
 
-int sdl_video_run_update_yuv_texture (SDL_Texture *texture, uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane,
+int vid_update_yuv_texture ( uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane,
 	int Ypitch, int Upitch, int Vpitch)
 {
 	SDL_LockMutex(sdl_video_run_mutex);
-	sdl_yuv_texture = texture;
 	yuv_texture_Yplane = Yplane;
 	yuv_texture_Uplane = Uplane;
 	yuv_texture_Vplane = Vplane;
@@ -663,30 +733,72 @@ int sdl_video_run_update_yuv_texture (SDL_Texture *texture, uint8_t *Yplane, uin
 	return sdl_video_run_result;
 }
 
-void sdl_video_run_destroy_texture(SDL_Texture *texture) {
-	SDL_LockMutex(sdl_video_run_mutex);
-	sdl_video_run_action = SDL_VIDEO_RUN_DESTROY_TEXTURE;
-	sdl_yuv_texture = texture;
-	SDL_CondSignal(sdl_video_run_cond);
-	SDL_CondWait(sdl_video_run_cond, sdl_video_run_mutex);
-	SDL_UnlockMutex(sdl_video_run_mutex);
+void vid_update_overlay_surface (SDL_Surface *tx, int x, int y) {
+    // Remember: tx is m_video_overlay[] passed from game::blit() 
+    // Careful not comment this part on testing, because this rect is used in vid_blit!
+    g_overlay_size_rect.x = (short)x;
+    g_overlay_size_rect.y = (short)y;
+    g_overlay_size_rect.w = tx->w;
+    g_overlay_size_rect.h = tx->h;
+    
+    // MAC: 8bpp to RGBA8888 conversion. Black pixels are considered totally transparent so they become 0x00000000;
+    SDL_LockMutex(overlay_surface_mutex);
+    for (int i = 0; i < (tx->w * tx->h); i++){
+        if (     *(  ((uint8_t*)tx->pixels)+i ) != 0x00   ) {
+	    *((uint32_t*)(g_screen_blitter->pixels)+i) = //0xff0000ff;
+	    (0x00000000 | tx->format->palette->colors[*((uint8_t*)(tx->pixels)+i)].r) << 24|
+	    (0x00000000 | tx->format->palette->colors[*((uint8_t*)(tx->pixels)+i)].g) << 16|
+	    (0x00000000 | tx->format->palette->colors[*((uint8_t*)(tx->pixels)+i)].b) << 8|
+	    0x000000ff;
+        }
+        else *((uint32_t*)(g_screen_blitter->pixels)+i) = 0x00000000;
+    }
+    SDL_UnlockMutex(overlay_surface_mutex);
+    // MAC: We update the overlay texture later, just when we are going to SDL_RenderCpy() it to the renderer.
+    // SDL_UpdateTexture(g_overlay_texture, &g_overlay_size_rect, (void *)g_screen_blitter->pixels, g_screen_blitter->pitch);
 }
 
-void sdl_video_run_update_renderer(SDL_Texture *texture) {
-	SDL_LockMutex(sdl_video_run_mutex);
-	sdl_yuv_texture = texture;
-	sdl_video_run_action = SDL_VIDEO_RUN_UPDATE_RENDERER;
-	SDL_CondSignal(sdl_video_run_cond);
-	SDL_CondWait(sdl_video_run_cond, sdl_video_run_mutex);
-	SDL_UnlockMutex(sdl_video_run_mutex);
+void vid_blit () {
+    SDL_LockMutex(sdl_video_run_mutex);
+    sdl_video_run_action = SDL_VIDEO_RUN_BLIT;
+    SDL_CondSignal(sdl_video_run_cond);
+    SDL_CondWait(sdl_video_run_cond, sdl_video_run_mutex);
+    SDL_UnlockMutex(sdl_video_run_mutex);
 }
 
 void sdl_video_run_end () {
-	SDL_LockMutex(sdl_video_run_mutex);
-	sdl_video_run_action = SDL_VIDEO_RUN_END_THREAD;
-	SDL_CondSignal(sdl_video_run_cond);
-	SDL_UnlockMutex(sdl_video_run_mutex);
-    	SDL_WaitThread(sdl_video_run_thread, (int *)NULL);
+    SDL_LockMutex(sdl_video_run_mutex);
+    sdl_video_run_action = SDL_VIDEO_RUN_END_THREAD;
+    SDL_CondSignal(sdl_video_run_cond);
+    SDL_UnlockMutex(sdl_video_run_mutex);
+    SDL_WaitThread(sdl_video_run_thread, (int *)NULL);
+}
+
+/*void vid_flip () {
+    //SDL_RenderPresent(g_renderer); // issue flip
+    SDL_LockMutex(sdl_video_run_mutex);
+    sdl_video_run_action = SDL_VIDEO_RUN_FLIP;
+    SDL_CondSignal(sdl_video_run_cond);
+    SDL_CondWait(sdl_video_run_cond, sdl_video_run_mutex);
+    SDL_UnlockMutex(sdl_video_run_mutex);
+}*/
+
+void vid_destroy_texture (SDL_Texture *texture) {
+    //SDL_RenderPresent(g_renderer); // issue flip
+    SDL_LockMutex(sdl_video_run_mutex);
+    sdl_video_run_action = SDL_VIDEO_RUN_DESTROY_TEXTURE;
+    sdl_texture = texture;
+    SDL_CondSignal(sdl_video_run_cond);
+    SDL_CondWait(sdl_video_run_cond, sdl_video_run_mutex);
+    SDL_UnlockMutex(sdl_video_run_mutex);
+}
+
+void vid_set_overlay_needs_update(bool needs) {
+    g_overlay_needs_update = needs;
+}
+
+void vid_set_yuv_video_needs_update(bool needs) {
+    g_yuv_video_needs_update = needs;
 }
 
 }

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -69,11 +69,13 @@ enum {
 bool init_display();
 
 // MAC: sdl_video_run thread block
+
 bool init_display();
 bool sdl_video_run_start();
 void sdl_video_run_end();
 
-SDL_Texture *sdl_video_run_create_yuv_texture (int width, int height);
+SDL_Texture *vid_create_yuv_texture (int width, int height);
+int vid_update_yuv_surface (uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane, int Ypitch, int Upitch, int Vpitch);
 int vid_update_yuv_texture (uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane, int Ypitch, int Upitch, int Vpitch);
 
 void vid_update_overlay_surface(SDL_Surface *tx, int x, int y);
@@ -128,9 +130,6 @@ bool get_force_aspect_ratio();
 
 unsigned int get_draw_width();
 unsigned int get_draw_height();
-
-void vid_set_overlay_needs_update(bool needs);
-void vid_set_yuv_video_needs_update(bool needs);
 
 }
 #endif

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -74,9 +74,11 @@ bool sdl_video_run_start();
 void sdl_video_run_end();
 
 SDL_Texture *sdl_video_run_create_yuv_texture (int width, int height);
-int sdl_video_run_update_yuv_texture (SDL_Texture *, uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane, int Ypitch, int Upitch, int Vpitch);
-void sdl_video_run_destroy_texture(SDL_Texture *);
-void sdl_video_run_update_renderer(SDL_Texture *);
+int vid_update_yuv_texture (uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane, int Ypitch, int Upitch, int Vpitch);
+
+void vid_update_overlay_surface(SDL_Surface *tx, int x, int y);
+void vid_destroy_texture(SDL_Texture *);
+void vid_blit();
 // MAC: sdl_video_run thread block ends here
 
 #ifdef USE_OPENGL
@@ -91,9 +93,6 @@ void vid_flip();
 // blanks the back video buffer (makes it black)
 void vid_blank();
 
-// blits an SDL Surface to the back buffer
-void vid_blit(SDL_Surface *srf, int x, int y);
-
 void display_repaint();
 bool load_bmps();
 bool draw_led(int, int, int);
@@ -102,8 +101,8 @@ void draw_overlay_leds(unsigned int led_values[], int num_values, int x, int y,
 void draw_singleline_LDP1450(char *LDP1450_String, int start_x, int y, SDL_Surface *overlay);
 bool draw_othergfx(int which, int x, int y, bool bSendToScreenBlitter = true);
 void free_bmps();
-SDL_Texture *load_one_bmp(const char *);
-void free_one_bmp(SDL_Texture *);
+SDL_Surface *load_one_bmp(const char *);
+void free_one_bmp(SDL_Surface *);
 void draw_rectangle(short x, short y, unsigned short w, unsigned short h,
                     unsigned char red, unsigned char green, unsigned char blue);
 SDL_Renderer *get_renderer();
@@ -129,5 +128,9 @@ bool get_force_aspect_ratio();
 
 unsigned int get_draw_width();
 unsigned int get_draw_height();
+
+void vid_set_overlay_needs_update(bool needs);
+void vid_set_yuv_video_needs_update(bool needs);
+
 }
 #endif


### PR DESCRIPTION
I have added working scoreboard overlays. Dragon's Lair at least can use it with "-useoverlayusb 1".
Other overlays can be also activated (by putting the corresponding SDL_RenderCopy() calls in VIDEO_RUN_BLIT), but the overlay framerate is limited to the vldp display_frame_callback() calls, because video::vid_blit() is called from there. Bad emulator design, I guess.
Ideally, vid_blit() should be called from game.cpp, in game::blit(), but having to put all texture or renderer related functions on the same thread causes that the YUV video operations have to wait for the overlay texture operations, so the FMV is not smooth then.