### PR TITLE
Rewrote the whole overlays stuff for not using another thread anymore…

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -324,6 +324,8 @@ bool game::init_video()
     float srcx;
     float srcy;
 
+    // Set up SDL display (create window, renderer, surfaces, textures...)
+    video::init_display();
     // set instance variables and local variables to the actual screen (or
     // window) dimension
     m_video_screen_width = w = video::get_screen_blitter()->w;

--- a/src/hypseus.cpp
+++ b/src/hypseus.cpp
@@ -183,7 +183,8 @@ int main(int argc, char **argv)
         // if the display initialized properly
         // MAC: init_display() call moved to the sdl_video_run thread: it's now
         // called at the begining of the sdl_video_run thread main function.
-	if (video::sdl_video_run_start() && video::load_bmps()) {
+	//if (video::load_bmps() && video::init_display()) {
+	if (video::load_bmps()) {
             if (sound::init()) {
                 if (SDL_input_init()) {
                     // if the roms were loaded successfully
@@ -282,7 +283,7 @@ int main(int argc, char **argv)
     }
 
     video::free_bmps(); // always do this no matter what
-    video::sdl_video_run_end();
+    video::deinit_display();
     
     video::shutdown_display(); // shut down the display. MAC: DON'T do this (calls SDL_Quit(VIDEO)!!)
                                // until you have ended the sdl_video_run thread AND freed renderer, etc.

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -68,19 +68,21 @@ enum {
 
 bool init_display();
 
-// MAC: sdl_video_run thread block
+// MAC: YUV surface protection block: it needs protection because it's accessed from both
+// the main "hypseus" thread and the vldp thread.
 
 bool init_display();
-bool sdl_video_run_start();
-void sdl_video_run_end();
+bool deinit_display();
 
 SDL_Texture *vid_create_yuv_texture (int width, int height);
-int vid_update_yuv_surface (uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane, int Ypitch, int Upitch, int Vpitch);
+void vid_setup_yuv_overlay (int width, int height);
+// MAC : REMEMBER, vid_update_yuv_overlay() ONLY updates the YUV surface. The YUV texture is updated on vid_blit()
+int vid_update_yuv_overlay (uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane, int Ypitch, int Upitch, int Vpitch);
 int vid_update_yuv_texture (uint8_t *Yplane, uint8_t *Uplane, uint8_t *Vplane, int Ypitch, int Upitch, int Vpitch);
 void vid_blank_yuv_texture ();
+void vid_free_yuv_overlay ();
 
 void vid_update_overlay_surface(SDL_Surface *tx, int x, int y);
-void vid_destroy_texture(SDL_Texture *);
 void vid_blit();
 // MAC: sdl_video_run thread block ends here
 
@@ -131,6 +133,11 @@ bool get_force_aspect_ratio();
 
 unsigned int get_draw_width();
 unsigned int get_draw_height();
+
+int get_yuv_overlay_width();
+int get_yuv_overlay_height();
+
+bool get_yuv_overlay_ready();
 
 }
 #endif


### PR DESCRIPTION
…. Much better now!

Previously, I fixed Hypseus for SDL2 thread-safety so it worked on the Raspberry Pi (and other platforms where SDL2 underlying GL calls needed to be on the same thread as the context creation calls), but my solution was a bit strange and sub-optimal.
Now I am doing things way better by simply putting the SDL2 context init call on the same thread (the main "hypseus" thread) than the SDL2 calls that do GL stuff under the hood. Separating the YUV overlay into a YUV "surface" and a YUV texture makes things a lot easier too, since YUV "surface" updating can be done from the VLDP thread with no problems at all, while access to the YUV texture is done on the main "hypseus" thread... where the SDL2 context was initialized too, as intended. Good stuff! 