### PR TITLE
Adds support fo hardware scoreboard over USB w/ FTDI interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,7 @@ add_dependencies( game vldp )
 add_dependencies( sound vldp )
 
 add_executable( hypseus hypseus.cpp globals.h )
-target_link_libraries( hypseus plog io timer sound video cpu game ${SDL2_LIBRARIES} ${SDL2_TTF_LIBRARIES} )
+target_link_libraries( hypseus plog io timer sound video cpu game ${SDL2_LIBRARIES} ${SDL2_TTF_LIBRARIES} ftdi1 )
 
 set_source_files_properties( testvldp.cpp PROPERTIES COMPILE_FLAGS -DSHOW_FRAMES)
 add_executable( testvldp testvldp.cpp )

--- a/src/game/lair.cpp
+++ b/src/game/lair.cpp
@@ -737,9 +737,14 @@ bool lair::init()
 
         // if user has also requested a hardware scoreboard, then enable that
         // too
-        if (get_scoreboard() != 0) {
+        if (get_scoreboard() & 0x01) {
             ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::HARDWARE);
         }
+	
+	// if user has also requested a USB scoreboard, then enable that too
+	if (get_scoreboard() & 0x02) {
+	    ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::USB);
+	}
 
         m_pScoreboard = pScoreboard;
     } else {

--- a/src/game/thayers.cpp
+++ b/src/game/thayers.cpp
@@ -141,10 +141,15 @@ bool thayers::init()
 
             // if user has also requested a hardware scoreboard, then enable
             // that too
-            if (get_scoreboard() != 0) {
+            if (get_scoreboard() & 0x01) {
                 ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::HARDWARE);
             }
 
+	    // if user has also requested a USB scoreboard, then enable that too
+	    if (get_scoreboard() & 0x02) {
+	        ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::USB);
+	    }
+	    
             m_pScoreboard = pScoreboard;
         } else {
             result = false;

--- a/src/io/cmdline.cpp
+++ b/src/io/cmdline.cpp
@@ -451,6 +451,7 @@ bool parse_cmd_line(int argc, char **argv)
 
     //////////////////////////////////////////////////////////////////////////////////////
 
+    set_scoreboard(0);      // Now this is a bitmapped type, so set it to NONE to start
     g_argc      = argc;
     g_argv      = argv;
     g_arg_index = 1; // skip name of executable from command line
@@ -608,7 +609,7 @@ bool parse_cmd_line(int argc, char **argv)
             }
 
             else if (strcasecmp(s, "-scoreboard") == 0) {
-                set_scoreboard(1);
+	        set_scoreboard(get_scoreboard() | 0x01);             // Bitmapped -- enable parallel SB
                 printline("Enabling external scoreboard...");
             } else if (strcasecmp(s, "-scoreport") == 0) {
                 get_next_word(s, sizeof(s));
@@ -617,6 +618,14 @@ bool parse_cmd_line(int argc, char **argv)
                 sprintf(s, "Setting scoreboard port to %x", u);
                 printline(s);
             }
+
+	    
+	    else if (strcasecmp(s, "-usbsb")==0)
+	    {
+	        set_scoreboard(get_scoreboard() | 0x02);             // Bitmapped -- enable USB SB
+		printline("Enabling USB scoreboard...");
+	    }
+
 
             // used to modify the dip switch settings of the game in question
             else if (strcasecmp(s, "-bank") == 0) {

--- a/src/scoreboard/CMakeLists.txt
+++ b/src/scoreboard/CMakeLists.txt
@@ -1,5 +1,6 @@
 set( LIB_SOURCES
     hw_scoreboard.cpp
+    usb_scoreboard.cpp
     img_scoreboard.cpp
     null_scoreboard.cpp
     overlay_scoreboard.cpp
@@ -10,6 +11,7 @@ set( LIB_SOURCES
 
 set( LIB_HEADERS
     hw_scoreboard.h
+    usb_scoreboard.h
     img_scoreboard.h
     null_scoreboard.h
     overlay_scoreboard.h

--- a/src/scoreboard/scoreboard_factory.cpp
+++ b/src/scoreboard/scoreboard_factory.cpp
@@ -2,6 +2,7 @@
 
 #include "scoreboard_factory.h"
 #include "hw_scoreboard.h"
+#include "usb_scoreboard.h"
 #include "null_scoreboard.h"
 #include "img_scoreboard.h"
 #include "overlay_scoreboard.h"
@@ -26,6 +27,9 @@ IScoreboard *ScoreboardFactory::GetInstance(ScoreboardType type,
 		break;
 	case HARDWARE:	// hardware scoreboard via parallel port
 		pRes = HwScoreboard::GetInstance(uWhichPort);
+		break;
+	case USB:	// Hardware scoreboard via USB
+	        pRes = USBScoreboard::GetInstance();
 		break;
 	}
 

--- a/src/scoreboard/scoreboard_factory.h
+++ b/src/scoreboard/scoreboard_factory.h
@@ -11,10 +11,11 @@ class ScoreboardFactory
 public:
 	typedef enum
 	{
-		NULLTYPE,		// null scoreboard (used for testing)
-		IMAGE,	// graphics drawn on the screen (no VLDP)
-		OVERLAY,	// overlay graphics drawn over VLDP video
-		HARDWARE,	// hardware scoreboard controlled via parallel port
+		NULLTYPE,  // null scoreboard (used for testing)
+		IMAGE,	   // graphics drawn on the screen (no VLDP)
+		OVERLAY,   // overlay graphics drawn over VLDP video
+		HARDWARE,  // hardware scoreboard controlled via parallel port
+	        USB,	   // hardware scoreboard controlled via USB
 	} ScoreboardType;
 
 	// call this to get a new scoreboard instance

--- a/src/scoreboard/usb_scoreboard.cpp
+++ b/src/scoreboard/usb_scoreboard.cpp
@@ -1,0 +1,72 @@
+#include "usb_scoreboard.h"
+#include <libftdi1/ftdi.h>
+#include <string.h>
+
+void USBScoreboard::DeleteInstance() { delete this; }
+
+IScoreboard *USBScoreboard::GetInstance() {
+  USBScoreboard *uRes = 0;
+
+  uRes = new USBScoreboard();
+  
+  // Try to init, if this fails, we fail
+  if (!uRes->USBInit() || !uRes->Init()) {
+    uRes->DeleteInstance();
+    uRes = 0;
+  }
+
+  return uRes;
+}
+
+
+bool USBScoreboard::USBInit() {
+  if ((ftdi = ftdi_new()) == NULL) { return -1; }
+  if (ftdi_usb_open_desc(ftdi, 0x0403, 0x6001, "Daphne_USB", NULL)<0) { return -2; }
+  if (ftdi_set_baudrate(ftdi, 1000000)<0) { return -3; }
+  return 0;
+}
+
+void USBScoreboard::USBShutdown() {
+  ftdi_usb_close(ftdi);
+  ftdi_free(ftdi);
+  ftdi=NULL;
+}
+
+USBScoreboard::USBScoreboard() { }
+
+USBScoreboard::~USBScoreboard() { USBShutdown(); }
+
+void USBScoreboard::Invalidate() { }
+
+bool USBScoreboard::RepaintIfNeeded() { return false; }
+
+bool USBScoreboard::set_digit(unsigned int uValue, WhichDigit which) {
+  unsigned int addr, bank;
+
+  uValue &= 0x0f   ;                    // Mask to allowable values
+  bank = (which & 0x08) ? 0x08 : 0x10;  // Bank write select
+  addr = which & 0x07;                  // Mask to allowable address values
+
+  // Construct buffer to write to USB
+  cbuf[0] = clk0l | nobank | addr;         // Clk low,  writes high
+  cbuf[1] = clksh | nobank | addr;         // Clk high, writes high
+  cbuf[2] = clk0l | bank   | addr;         // Clk low,  one write low
+  cbuf[3] = clksh | bank   | addr;         // Clk high, one write low
+  cbuf[4] = clk1l |          uValue;       // Clk low
+  cbuf[5] = clksh |          uValue;       // Clk high
+  cbuf[6] = clk0l | nobank | addr;         // Clk low,  writes high
+  cbuf[7] = clksh | nobank | addr;         // Clk high, writes high
+
+  // Write data to port
+  ftdi_write_data(ftdi, cbuf, 8);
+  return true;
+}
+ 
+bool USBScoreboard::is_repaint_needed() { return false; }
+
+bool USBScoreboard::get_digit(unsigned int &uValue, WhichDigit which) {
+	uValue = m_DigitValues[which];
+	return true;
+}
+
+bool USBScoreboard::ChangeVisibility(bool bDontCare) { return false; }

--- a/src/scoreboard/usb_scoreboard.h
+++ b/src/scoreboard/usb_scoreboard.h
@@ -1,0 +1,53 @@
+#ifndef USB_SCOREBOARD_H
+#define USB_SCOREBOARD_H
+
+#include "scoreboard_interface.h"
+#include <libftdi1/ftdi.h>
+
+#define clk0l  0x40
+#define clk1l  0x80
+#define clksh  0xc0
+#define nobank 0x18
+
+class ScoreboardFactory;
+
+class USBScoreboard : public IScoreboard
+{
+	// allow ScoreboardFactory to call our GetInstance
+	friend class ScoreboardFactory;
+
+public:
+	// I made GetInstance public so my 'clear_hw_scoreboard' program could access this
+	//  directly without linking against the other scoreboard types.
+	static IScoreboard *GetInstance();
+
+	void DeleteInstance();
+
+	void Invalidate();
+
+	bool RepaintIfNeeded();
+
+	bool ChangeVisibility(bool bVisible);
+
+	bool set_digit(unsigned int uValue, WhichDigit which);
+
+	bool is_repaint_needed();
+
+	bool get_digit(unsigned int &uValue, WhichDigit which);
+
+protected:
+private:
+	// initialize the parallel port
+	bool USBInit();
+
+	// shutdown the parallel port
+	void USBShutdown();
+
+	USBScoreboard();
+	virtual ~USBScoreboard();
+
+	unsigned char cbuf[8];
+	struct ftdi_context *ftdi;
+};
+
+#endif // USB_SCOREBOARD_H


### PR DESCRIPTION
This code has been tested on x86/Linux and raspberry pi linux, but not Windows since I don't have a working build environment.  It adds a dependency for the (open source) libftdi1.

The FT232 is configures as digital I/O instead of as a serial port, and bit-bangs TTL chips on the interface board to act like the original parallel port driver.

Demo:
https://www.youtube.com/watch?v=H2MnRZ6lvlU