### PR TITLE
Fix assertion failure with current SDL2 versions.

### DIFF
--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -803,7 +803,9 @@ void vid_blit () {
 
     // Sadly, we have to RenderCopy the YUV texture on every blitting strike, because
     // the image on the renderer gets "dirty" with previous overlay frames on top of the yuv.
-    SDL_RenderCopy(g_renderer, g_yuv_texture, NULL, NULL); 
+    if(g_yuv_texture) {
+        SDL_RenderCopy(g_renderer, g_yuv_texture, NULL, NULL); 
+    }
 
     // If there's an overlay texture, it means we are using some kind of overlay,
     // be it LEDs or any other thing, so RenderCopy it to the renderer ON TOP of the YUV video.


### PR DESCRIPTION
Hi @h0tw1r3 

This is needed so Hypseus (with overlays) works with current SDL2 versions.
Please merge :)