### PR TITLE
Make USB Scoreboard optional.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,12 +4,13 @@ set(PKG_VERSION "v1.2.0")
 
 project(hypseus)
 
-option(BENCHMARK    "Benchmark"  OFF)
-option(DEBUG        "Debug"      OFF)
-option(VLDP_DEBUG   "VLDP Debug" OFF)
-option(CPU_DEBUG    "CPU Debug"  OFF)
-option(BUILD_SINGE  "Singe"      OFF)
-option(BUILDBOT     "Buildbot"   OFF)
+option(BENCHMARK        "Benchmark"             OFF)
+option(DEBUG            "Debug"                 OFF)
+option(VLDP_DEBUG       "VLDP Debug"            OFF)
+option(CPU_DEBUG        "CPU Debug"             OFF)
+option(BUILD_SINGE      "Singe"                 OFF)
+option(BUILDBOT         "Buildbot"              OFF)
+option(USB_SCOREBOARD   "UsbScoreboard"         OFF)
 
 if( NOT CMAKE_BUILD_TYPE )
     set(CMAKE_BUILD_TYPE "Release")
@@ -103,7 +104,11 @@ add_dependencies( game vldp )
 add_dependencies( sound vldp )
 
 add_executable( hypseus hypseus.cpp globals.h )
-target_link_libraries( hypseus plog io timer sound video cpu game ${SDL2_LIBRARIES} ${SDL2_TTF_LIBRARIES} ftdi1 )
+target_link_libraries( hypseus plog io timer sound video cpu game ${SDL2_LIBRARIES} ${SDL2_TTF_LIBRARIES})
+
+if(USB_SCOREBOARD)
+    add_library(ftdi1)
+endif()
 
 set_source_files_properties( testvldp.cpp PROPERTIES COMPILE_FLAGS -DSHOW_FRAMES)
 add_executable( testvldp testvldp.cpp )

--- a/src/scoreboard/scoreboard_factory.cpp
+++ b/src/scoreboard/scoreboard_factory.cpp
@@ -28,11 +28,12 @@ IScoreboard *ScoreboardFactory::GetInstance(ScoreboardType type,
 	case HARDWARE:	// hardware scoreboard via parallel port
 		pRes = HwScoreboard::GetInstance(uWhichPort);
 		break;
+#ifdef USB_SCOREBOARD
 	case USB:	// Hardware scoreboard via USB
 	        pRes = USBScoreboard::GetInstance();
 		break;
+#endif
 	}
-
 	// set the annunciator value while we're here
 	if (pRes != NULL)
 	{

--- a/src/scoreboard/usb_scoreboard.cpp
+++ b/src/scoreboard/usb_scoreboard.cpp
@@ -1,3 +1,4 @@
+#ifdef USB_SCOREBOARD
 #include "usb_scoreboard.h"
 #include <libftdi1/ftdi.h>
 #include <string.h>
@@ -70,3 +71,4 @@ bool USBScoreboard::get_digit(unsigned int &uValue, WhichDigit which) {
 }
 
 bool USBScoreboard::ChangeVisibility(bool bDontCare) { return false; }
+#endif //USB_SCOREBOARD

--- a/src/scoreboard/usb_scoreboard.h
+++ b/src/scoreboard/usb_scoreboard.h
@@ -1,3 +1,4 @@
+#ifdef USB_SCOREBOARD
 #ifndef USB_SCOREBOARD_H
 #define USB_SCOREBOARD_H
 
@@ -51,3 +52,4 @@ private:
 };
 
 #endif // USB_SCOREBOARD_H
+#endif //USB_SCOREBOARD


### PR DESCRIPTION
This is mainly because USB Scoreboard requires libftdi1, and that's an unwanted added dependency for most Hypseus usercases.